### PR TITLE
feat: add battle property to svg generation

### DIFF
--- a/src/obsidian_tears_nft/main.mo
+++ b/src/obsidian_tears_nft/main.mo
@@ -1287,6 +1287,8 @@ actor class ObsidianTears() = this {
     let height : Text = imageHeight;
     let ctype : Text = imageType;
     let path = Iter.toArray(Text.tokens(request.url, #text("/")));
+    let battle = Text.equal(Option.get(_getParam(request.url, "battle"), "false"), "true");
+
     switch (_getParam(request.url, "tokenid")) {
       case (?tokenid) {
         switch (_getTokenIndex(tokenid)) {
@@ -1302,7 +1304,7 @@ actor class ObsidianTears() = this {
                           return {
                             status_code = 200;
                             headers = [("content-type", ctype), ("cache-control", "public, max-age=15552000")];
-                            body = Text.encodeUtf8(SVG.make(Blob.toArray(data), height, width));
+                            body = Text.encodeUtf8(SVG.make(Blob.toArray(data), height, width, battle));
                             streaming_strategy = null;
                           };
                         };
@@ -1313,7 +1315,7 @@ actor class ObsidianTears() = this {
                     return {
                       status_code = 200;
                       headers = [("content-type", ctype), ("cache-control", "public, max-age=15552000")];
-                      body = Text.encodeUtf8(SVG.make(Blob.toArray(data), height, width));
+                      body = Text.encodeUtf8(SVG.make(Blob.toArray(data), height, width, battle));
                       streaming_strategy = null;
                     };
                   };
@@ -1340,7 +1342,7 @@ actor class ObsidianTears() = this {
                       return {
                         status_code = 200;
                         headers = [("content-type", ctype), ("cache-control", "public, max-age=15552000")];
-                        body = Text.encodeUtf8(SVG.make(Blob.toArray(data), height, width));
+                        body = Text.encodeUtf8(SVG.make(Blob.toArray(data), height, width, battle));
                         streaming_strategy = null;
                       };
                     };
@@ -1350,7 +1352,7 @@ actor class ObsidianTears() = this {
                 return {
                   status_code = 200;
                   headers = [("content-type", ctype), ("cache-control", "public, max-age=15552000")];
-                  body = Text.encodeUtf8(SVG.make(Blob.toArray(data), height, width));
+                  body = Text.encodeUtf8(SVG.make(Blob.toArray(data), height, width, battle));
                   streaming_strategy = null;
                 };
               };

--- a/src/obsidian_tears_nft/svg.mo
+++ b/src/obsidian_tears_nft/svg.mo
@@ -18,7 +18,7 @@ import Weapons "elements/weapons";
 // order of assets
 
 module {
-  public func make(seed : [Nat8], height : Text, width : Text) : Text {
+  public func make(seed : [Nat8], height : Text, width : Text, battle: Bool) : Text {
     var svg : Text = "<?xml version=\"1.0\" encoding=\"utf-8\"?><svg style=\"height:" #height # "px;width:" #width # "px;\" version=\"1.1\" id=\"generated\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" x=\"0px\" y=\"0px\" viewBox=\"0 0 " #width # " " #height # "\" xml:space=\"preserve\">";
     // background
     // class badge
@@ -32,8 +32,11 @@ module {
     // cape
     // weapon
     // og badge
-    svg #= "<g id=\"backgrounds\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Backgrounds.elements[Nat8.toNat(seed[0])] # "\" /></g>";
-    svg #= "<g id=\"class_badge\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Classes.elements[Nat8.toNat(seed[1])] # "\" /></g>";
+    if (battle == false) {
+      svg #= "<g id=\"backgrounds\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Backgrounds.elements[Nat8.toNat(seed[0])] # "\" /></g>";
+      svg #= "<g id=\"class_badge\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Classes.elements[Nat8.toNat(seed[1])] # "\" /></g>";
+      svg #= "<g id=\"og_badge\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #OgBadge.elements[0] # "\" /></g>";
+    };
     svg #= "<g id=\"outfit\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Outfits.elements[Nat8.toNat(seed[2])] # "\" /></g>";
     svg #= "<g id=\"skin\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Skins.elements[Nat8.toNat(seed[3])] # "\" /></g>";
     if (seed[4] == 1) {
@@ -46,7 +49,6 @@ module {
     svg #= "<g id=\"cape\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Capes.elements[Nat8.toNat(seed[9])] # "\" /></g>";
     svg #= "<g id=\"weapon\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Weapons.elements[Nat8.toNat(seed[10])] # "\" /></g>";
     if (seed[11] == 1) {
-      svg #= "<g id=\"og_badge\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #OgBadge.elements[0] # "\" /></g>";
     };
     svg #= "</svg>";
     return svg;

--- a/src/obsidian_tears_nft/svg.mo
+++ b/src/obsidian_tears_nft/svg.mo
@@ -35,7 +35,9 @@ module {
     if (battle == false) {
       svg #= "<g id=\"backgrounds\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Backgrounds.elements[Nat8.toNat(seed[0])] # "\" /></g>";
       svg #= "<g id=\"class_badge\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Classes.elements[Nat8.toNat(seed[1])] # "\" /></g>";
-      svg #= "<g id=\"og_badge\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #OgBadge.elements[0] # "\" /></g>";
+      if (seed[11] == 1) {
+        svg #= "<g id=\"og_badge\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #OgBadge.elements[0] # "\" /></g>";
+      };
     };
     svg #= "<g id=\"outfit\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Outfits.elements[Nat8.toNat(seed[2])] # "\" /></g>";
     svg #= "<g id=\"skin\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Skins.elements[Nat8.toNat(seed[3])] # "\" /></g>";
@@ -48,8 +50,6 @@ module {
     svg #= "<g id=\"magic_ring\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #MagicRings.elements[Nat8.toNat(seed[8])] # "\" /></g>";
     svg #= "<g id=\"cape\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Capes.elements[Nat8.toNat(seed[9])] # "\" /></g>";
     svg #= "<g id=\"weapon\"><image style=\"height:" #height # "px;width:" #width # "px;\" href=\"" #Weapons.elements[Nat8.toNat(seed[10])] # "\" /></g>";
-    if (seed[11] == 1) {
-    };
     svg #= "</svg>";
     return svg;
   };


### PR DESCRIPTION
Parse `battle` parameter from the request URL. Value defaults to `false`
When `battle` is`true` character is returned without `background`, `class badge` and `og badge`

Preview: https://www.loom.com/share/707eedfc71324dca898bcb2b6e8a4fdc?sid=10be9576-9554-4f36-925a-5200f5c29f23